### PR TITLE
Add package dependencies, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,18 @@
 # libinput-gestures-qt
 
-## Description
-
-### Intro
+## Intro
 This app is a setup tool for [libinput-gestures](https://github.com/bulletmark/libinput-gestures), a utility that allows
 to map touchpad gestures to shell commands.
 The problem is that libinput-gestures does not provide a graphical interface and suggests interacting with
 `libinput-gestures` and `libinput-gestures-setup` binaries and `libinput-gestures.conf` configuration file.
 I find it too difficult and that is why I decided to make a qt-based app for libinput-gestures.
 
-### Install
-You can install the latest release version from PyPI by running:  
-`sudo pip3 install libinput-gestures-qt`
+## Dependencies
+This package requires python version 3.5 or newer, PyQt5 and libinput-gestures.
 
-Please note, that this package doesn't specify the dependencies because installing them with pip
-breaks my pip :)  
-This package needs: `pyqt5`, `subprocess` and `pathlib`. I recommend to install them using your PM instead of pip.
+## Install from PyPI
+You can install the latest release version from PyPI by running:  
+`$ sudo pip3 install libinput-gestures-qt`
 
 This will install the app and make a desktop entry so that you could run it by clicking in
 your app menu.
@@ -24,7 +21,20 @@ This app was tested for Debian and OpenSUSE and seems to work stably. However,
 it's not final and one cannot yet be sure that it will work well. Nevertheless, I
 already use it myself.
 
-### Features
+## Install from git checkout
+You can also install this app by following these steps:
+1. `$ git clone https://github.com/OneAdder/libinput_gestures_qt`
+2. `$ cd libinput_gestures_qt`
+3. `$ mkvirtualenv -p libinput-gestures-qt`     # virtualenvwrapper must be installed
+4. `$ pip install -e .`
+
+This will install the app to a virtualenv that does not affect the rest of the system.
+
+## Install testing packages
+To also install packages for testing, do:  
+`$ pip install -e .[dev]`
+
+## Features
 1) Handsome main window with current configuration displayed in human-readable form:
 ![image](https://user-images.githubusercontent.com/19834976/56821309-9521b080-6856-11e9-8a2c-ee12b31c9fa4.png)
 2) Adding new gestures.  
@@ -36,4 +46,3 @@ It's possible to map a gesture to a command, keyboard shortcut or kwin shortcut 
 ![image](https://user-images.githubusercontent.com/19834976/56820982-ef6e4180-6855-11e9-875d-a573157dada2.png)
 4) Control libinput-gestures-setup.  
 ![image](https://user-images.githubusercontent.com/19834976/56821022-04e36b80-6856-11e9-996c-e0db2c26e9f7.png)
-

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,25 @@
 from setuptools import setup
 
-setup(name='libinput_gestures_qt',
-      version='0.4',
-      description='Qt interface for libinput-gestures (works best with Plasma)',
-      url='https://github.com/OneAdder/libinput_gestures_qt',
-      author='Michael Voronov',
-      author_email='mikivo@list.ru',
-      license='GPLv3',
-      packages=['libinput_gestures_qt'],
-      #actually, you also need pyqt5 and pathlib. But use your package manager, not pip!
-      #pip died after installing one of those!
-      zip_safe=False,
-      scripts=['libinput-gestures-qt'],
-      data_files=[
+setup(
+    name='libinput_gestures_qt',
+    version='0.4',
+    description='Qt interface for libinput-gestures (works best with Plasma)',
+    url='https://github.com/OneAdder/libinput_gestures_qt',
+    author='Michael Voronov',
+    author_email='mikivo@list.ru',
+    license='GPLv3',
+    packages=['libinput_gestures_qt'],
+    install_requires=['PyQt5'],
+    extras_require={
+        'dev': ['pytest']
+    },
+    zip_safe=False,
+    scripts=['libinput-gestures-qt'],
+    data_files=[
         ('share/applications', ['libinput_gestures_qt/logo/libinput-gestures-qt.desktop']),
         ('share/pixmaps/', ['libinput_gestures_qt/logo/libinput-gestures-qt.png']),
         ('local/share/applications', ['libinput_gestures_qt/logo/libinput-gestures-qt.desktop']),
         ('local/share/pixmaps/', ['libinput_gestures_qt/logo/libinput-gestures-qt.png']),
-      ],
-      include_package_data=True) 
+    ],
+    include_package_data=True
+)


### PR DESCRIPTION
I see you mention that you have had problems with dependencies and installing with pip as root. I believe that installing with pip as root is normally discouraged because you risk messing up python packages installed by the package manager.

So in here i add PyQt5 as dependency and install with `pip install -e .` in a virtualenv. I then have to be in the virtualenv to run the executable, and i guess i won't see any icon in the menu, but it runs and is separated from the rest of the system.

I guess in the long run, it would be good to prepare packages for the distros` package managers?